### PR TITLE
Release with updated pyadtpulse for HA 2025 support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # Created by https://www.toptal.com/developers/gitignore/api/python,pycharm,VisualStudioCode,macos
 # Edit at https://www.toptal.com/developers/gitignore?templates=python,pycharm,VisualStudioCode,macos
+.devcontainer/
 
 ### macOS ###
 # General
@@ -8,7 +9,8 @@
 .LSOverride
 
 # Icon must end with two \r
-Icon
+Icon
+
 
 # Thumbnails
 ._*

--- a/custom_components/adtpulse/manifest.json
+++ b/custom_components/adtpulse/manifest.json
@@ -9,7 +9,7 @@
     "iot_class": "cloud_push",
     "issue_tracker": "https://github.com/rsnodgrass/hass-adtpulse/issues",
     "requirements": [
-        "pyadtpulse>=1.2.10"
+        "pyadtpulse>=1.2.11"
     ],
-    "version": "0.4.7"
+    "version": "0.4.8"
 }

--- a/hacs.json
+++ b/hacs.json
@@ -1,6 +1,6 @@
 {
   "name": "ADT Pulse",
-  "homeassistant": "2024.4.0",
+  "homeassistant": "2025.7.1",
   "render_readme": true,
   "country": ["US", "CA"]
 }


### PR DESCRIPTION
Attempts to fix support for HA 2025 where python has been upgraded.

- Upgrade pyadtpulse to version1.2.11
- Update this version to 0.4.8